### PR TITLE
Cleaned dataset loading with parallel processing

### DIFF
--- a/scripts/initialize_dataset.sh
+++ b/scripts/initialize_dataset.sh
@@ -43,17 +43,30 @@ fi
 echo -e "${GREEN}✓ Dataset download completed${NC}"
 echo ""
 
-# Step 3: Filter ground truth
-echo -e "${RED}Step 3: Filtering Ground Truth Labels${NC}"
-echo -e "${BLUE}Running: python utils/dataset/filter_ground_truth.py${NC}"
-python utils/dataset/filter_ground_truth.py
+# Step 3: Filter ground truth (Optional)
+echo -e "${RED}Step 3: Filtering Ground Truth Labels (Optional)${NC}"
+echo "Ground truth filtering will process and filter the downloaded labels."
+echo ""
+echo -n "Do you want to filter ground truth labels? (y/N): "
+read -r FILTER_RESPONSE
 
-if [ $? -ne 0 ]; then
-    echo -e "${RED}Error: Ground truth filtering failed${NC}"
-    exit 1
+FILTER_RESPONSE=$(echo "$FILTER_RESPONSE" | tr '[:upper:]' '[:lower:]')
+
+if [[ "$FILTER_RESPONSE" == "y" || "$FILTER_RESPONSE" == "yes" ]]; then
+    echo ""
+    echo -e "${BLUE}Running: python utils/dataset/filter_ground_truth.py${NC}"
+    python utils/dataset/filter_ground_truth.py
+
+    if [ $? -ne 0 ]; then
+        echo -e "${RED}Error: Ground truth filtering failed${NC}"
+        exit 1
+    fi
+
+    echo -e "${GREEN}✓ Ground truth filtering completed${NC}"
+else
+    echo -e "${RED}⊘ Skipping ground truth filtering${NC}"
 fi
 
-echo -e "${GREEN}✓ Ground truth filtering completed${NC}"
 echo ""
 
 # Step 4: Ask about dataset cleaning (BEFORE generating splits)
@@ -134,14 +147,21 @@ echo -e "${GREEN}  Dataset Initialization Complete! ✓${NC}"
 echo -e "${GREEN}========================================${NC}"
 echo ""
 echo "Summary of generated files:"
-echo "  - dataset/manifest.json          (downloaded video manifest)"
-echo "  - dataset/ground_truth.json      (filtered ground truth labels)"
-echo "  - dataset/qved_train.json        (training split)"
-echo "  - dataset/qved_val.json          (validation split)"
-echo "  - dataset/qved_test.json         (test split)"
+echo "  - dataset/manifest.json               (downloaded video manifest)"
+
+if [[ "$FILTER_RESPONSE" == "y" || "$FILTER_RESPONSE" == "yes" ]]; then
+    echo "  - dataset/ground_truth.json           (filtered ground truth labels)"
+fi
+
+echo "  - dataset/qved_train.json             (training split - fine-grained labels)"
+echo "  - dataset/qved_val.json               (validation split - fine-grained labels)"
+echo "  - dataset/qved_test.json              (test split - fine-grained labels)"
+echo "  - dataset/qved_feedbacks_train.json   (training split - feedbacks)"
+echo "  - dataset/qved_feedbacks_val.json     (validation split - feedbacks)"
+echo "  - dataset/qved_feedbacks_test.json    (test split - feedbacks)"
 
 if [[ "$CLEAN_RESPONSE" == "y" || "$CLEAN_RESPONSE" == "yes" ]]; then
-    echo "  - cleaned_dataset/               (quality-filtered videos)"
+    echo "  - cleaned_dataset/                    (quality-filtered videos)"
     echo "  - cleaned_dataset/cleaning_report.csv"
 fi
 
@@ -150,5 +170,7 @@ if [[ "$AUGMENT_RESPONSE" == "y" || "$AUGMENT_RESPONSE" == "yes" ]]; then
     echo "  - JSON files updated with augmented video paths"
 fi
 
+echo ""
+echo "Note: Same videos are in the same splits (train/val/test) for both fine-grained labels and feedbacks datasets."
 echo ""
 echo "You can now proceed with model training!"

--- a/scripts/initialize_dataset.sh
+++ b/scripts/initialize_dataset.sh
@@ -30,10 +30,26 @@ fi
 echo -e "${GREEN}✓ Will download ${VIDEO_COUNT} videos per exercise class${NC}"
 echo ""
 
+# Ask about parallel downloads
+echo -n "Use parallel downloads for faster processing? (y/N): "
+read -r PARALLEL_RESPONSE
+
+PARALLEL_RESPONSE=$(echo "$PARALLEL_RESPONSE" | tr '[:upper:]' '[:lower:]')
+
+PARALLEL_FLAG=""
+if [[ "$PARALLEL_RESPONSE" == "y" || "$PARALLEL_RESPONSE" == "yes" ]]; then
+    PARALLEL_FLAG="--parallel"
+    echo -e "${GREEN}✓ Parallel downloads enabled${NC}"
+else
+    echo -e "${BLUE}ℹ Using sequential downloads (default)${NC}"
+fi
+
+echo ""
+
 # Step 2: Download dataset
 echo -e "${RED}Step 2: Downloading Dataset from HuggingFace${NC}"
-echo -e "${BLUE}Running: python utils/dataset/load_dataset.py ${VIDEO_COUNT}${NC}"
-python utils/dataset/load_dataset.py "$VIDEO_COUNT"
+echo -e "${BLUE}Running: python utils/dataset/load_dataset.py ${VIDEO_COUNT} ${PARALLEL_FLAG}${NC}"
+python utils/dataset/load_dataset.py "$VIDEO_COUNT" $PARALLEL_FLAG
 
 if [ $? -ne 0 ]; then
     echo -e "${RED}Error: Dataset download failed${NC}"

--- a/utils/dataset/load_dataset.py
+++ b/utils/dataset/load_dataset.py
@@ -4,6 +4,7 @@ Features:
 - Preserves folder structure
 - Downloads fine_grained_labels.json (complete ground truth)
 - Creates manifest.json of downloaded videos
+- Optional parallel downloads for faster processing
 """
 
 import os
@@ -14,13 +15,17 @@ from pathlib import Path
 from huggingface_hub import list_repo_files, hf_hub_download
 import shutil
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from threading import Lock
 
 REPO_ID = "EdgeVLM-Labs/QVED-Test-Dataset"
 LOCAL_DIR = Path("dataset")  # local download directory
 MAX_PER_CLASS = 5
 FILE_EXT = ".mp4"
 GROUND_TRUTH_FILE = "fine_grained_labels.json"
+FEEDBACKS_FILE = "feedbacks_short_clips.json"
 RANDOM_SEED = 42
+MAX_WORKERS = 4  # Number of parallel download threads
 
 
 def collect_videos(repo_id):
@@ -41,13 +46,37 @@ def collect_videos(repo_id):
     return by_class, all_files
 
 
-def sample_and_download(by_class, repo_id, local_dir, max_per_class):
+def download_single_file(repo_id, rel_path, target_path, cls):
+    """Download a single file with retry logic. Returns (target_path, cls, success)."""
+
+    while True:
+        try:
+            cached_path = hf_hub_download(
+                repo_id=repo_id,
+                filename=rel_path,
+                repo_type="dataset",
+            )
+
+            shutil.copy2(cached_path, target_path)
+            return (str(target_path), cls, True)
+        except Exception as e:
+            if "429" in str(e) or "Too Many Requests" in str(e):
+                print(f"⚠️ Rate limit hit (429). Waiting ~ 3 minutes before retrying {rel_path}...")
+                time.sleep(200)
+            else:
+                print(f"⚠️ Failed to download {rel_path}: {e}")
+                return (str(target_path), cls, False)
+
+
+def sample_and_download(by_class, repo_id, local_dir, max_per_class, parallel=False):
     """Samples random videos per class and downloads them into <local_dir>/<class>/<file> (no duplicate subfolders)."""
 
     random.seed(RANDOM_SEED)
     manifest = {}
     total_downloaded = 0
 
+    # Prepare all download tasks
+    download_tasks = []
     for cls, vids in by_class.items():
         class_dir = local_dir / cls
         class_dir.mkdir(parents=True, exist_ok=True)
@@ -55,43 +84,50 @@ def sample_and_download(by_class, repo_id, local_dir, max_per_class):
         print(f"🎥 {cls}: {len(sample)} sampled of {len(vids)} available")
 
         for rel_path in sample:
-            filename = os.path.basename(rel_path)  # e.g., "00018209.mp4"
+            filename = os.path.basename(rel_path)
             target_path = class_dir / filename
+            download_tasks.append((repo_id, rel_path, target_path, cls))
 
-            while True:
-                try:
-                    cached_path = hf_hub_download(
-                        repo_id=repo_id,
-                        filename=rel_path,
-                        repo_type="dataset",
-                    )
+    if parallel:
+        # Parallel download
+        print(f"⚡ Using parallel downloads with {MAX_WORKERS} workers")
+        manifest_lock = Lock()
 
-                    shutil.copy2(cached_path, target_path)
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = {
+                executor.submit(download_single_file, repo_id, rel_path, target_path, cls): (rel_path, cls)
+                for repo_id, rel_path, target_path, cls in download_tasks
+            }
 
-                    manifest[str(target_path)] = cls
-                    total_downloaded += 1
-                    break
-                except Exception as e:
-                    if "429" in str(e) or "Too Many Requests" in str(e):
-                        print(f"⚠️ Rate limit hit (429). Waiting ~ 3 minutes before retrying {rel_path}...")
-                        time.sleep(200)
-                    else:
-                        print(f"⚠️ Failed to download {rel_path}: {e}")
-                        break
+            for future in as_completed(futures):
+                target_path, cls, success = future.result()
+                if success:
+                    with manifest_lock:
+                        manifest[target_path] = cls
+                        total_downloaded += 1
+                        print(f"✓ Downloaded {os.path.basename(target_path)} ({total_downloaded}/{len(download_tasks)})")
+    else:
+        # Sequential download (default)
+        print(f"📥 Using sequential downloads")
+        for repo_id, rel_path, target_path, cls in download_tasks:
+            target_path_str, cls, success = download_single_file(repo_id, rel_path, target_path, cls)
+            if success:
+                manifest[target_path_str] = cls
+                total_downloaded += 1
 
     print(f"\n✅ Download complete: {total_downloaded} videos.")
     return manifest
 
 
-def download_ground_truth(repo_id, local_dir, all_files):
-    """Downloads fine_grained_labels.json if present."""
+def download_json_file(repo_id, local_dir, all_files, json_filename):
+    """Downloads a JSON file if present."""
 
-    candidates = [f for f in all_files if f.endswith(GROUND_TRUTH_FILE)]
+    candidates = [f for f in all_files if f.endswith(json_filename)]
     if not candidates:
-        print(f"⚠️ No {GROUND_TRUTH_FILE} found in repo.")
+        print(f"⚠️ No {json_filename} found in repo.")
         return None
 
-    gt_path = local_dir / GROUND_TRUTH_FILE
+    json_path = local_dir / json_filename
     try:
         hf_hub_download(
             repo_id=repo_id,
@@ -99,11 +135,21 @@ def download_ground_truth(repo_id, local_dir, all_files):
             local_dir=str(local_dir),
             repo_type="dataset",
         )
-        print(f"🧠 Ground truth file downloaded to: {gt_path}")
-        return gt_path
+        print(f"📄 {json_filename} downloaded to: {json_path}")
+        return json_path
     except Exception as e:
-        print(f"⚠️ Failed to download {GROUND_TRUTH_FILE}: {e}")
+        print(f"⚠️ Failed to download {json_filename}: {e}")
         return None
+
+
+def download_ground_truth(repo_id, local_dir, all_files):
+    """Downloads fine_grained_labels.json if present."""
+    return download_json_file(repo_id, local_dir, all_files, GROUND_TRUTH_FILE)
+
+
+def download_feedbacks(repo_id, local_dir, all_files):
+    """Downloads feedbacks_short_clips.json if present."""
+    return download_json_file(repo_id, local_dir, all_files, FEEDBACKS_FILE)
 
 
 def save_manifest(manifest, local_dir):
@@ -117,20 +163,33 @@ def save_manifest(manifest, local_dir):
 
 
 def main():
-
     max_per_class = MAX_PER_CLASS
-    if len(sys.argv) > 1:
-        try:
-            max_per_class = int(sys.argv[1])
-            print(f"📊 Using MAX_PER_CLASS = {max_per_class} (from command line)")
-        except ValueError:
-            print(f"⚠️ Invalid argument. Using default MAX_PER_CLASS = {MAX_PER_CLASS}")
+    parallel = False
+
+    # Parse command line arguments
+    # Usage: python load_dataset.py [max_per_class] [--parallel]
+    args = sys.argv[1:]
+
+    for arg in args:
+        if arg == "--parallel":
+            parallel = True
+            print(f"⚡ Parallel download mode enabled")
+        else:
+            try:
+                max_per_class = int(arg)
+                print(f"📊 Using MAX_PER_CLASS = {max_per_class} (from command line)")
+            except ValueError:
+                print(f"⚠️ Invalid argument '{arg}'. Using default MAX_PER_CLASS = {MAX_PER_CLASS}")
 
     LOCAL_DIR.mkdir(parents=True, exist_ok=True)
     by_class, all_files = collect_videos(REPO_ID)
-    manifest = sample_and_download(by_class, REPO_ID, LOCAL_DIR, max_per_class)
+    manifest = sample_and_download(by_class, REPO_ID, LOCAL_DIR, max_per_class, parallel=parallel)
     save_manifest(manifest, LOCAL_DIR)
+
+    # Download JSON files
     download_ground_truth(REPO_ID, LOCAL_DIR, all_files)
+    download_feedbacks(REPO_ID, LOCAL_DIR, all_files)
+
     print("🏁 Dataset download completed.")
 
 

--- a/utils/dataset/qved_from_fine_labels.py
+++ b/utils/dataset/qved_from_fine_labels.py
@@ -2,16 +2,20 @@ import json
 import os
 import random
 from pathlib import Path
-from collections import defaultdict
 
 # Paths
 BASE_DIR = Path("dataset")
-FINE_LABELS_JSON = BASE_DIR / "ground_truth.json"
+FINE_GRAINED_JSON = BASE_DIR / "fine_grained_labels.json"
+FEEDBACKS_JSON = BASE_DIR / "feedbacks_short_clips.json"
 MANIFEST_JSON = BASE_DIR / "manifest.json"
 OUTPUT_TRAIN_JSON = BASE_DIR / "qved_train.json"
 OUTPUT_VAL_JSON = BASE_DIR / "qved_val.json"
 OUTPUT_TEST_JSON = BASE_DIR / "qved_test.json"
+OUTPUT_FEEDBACKS_TRAIN_JSON = BASE_DIR / "qved_feedbacks_train.json"
+OUTPUT_FEEDBACKS_VAL_JSON = BASE_DIR / "qved_feedbacks_val.json"
+OUTPUT_FEEDBACKS_TEST_JSON = BASE_DIR / "qved_feedbacks_test.json"
 USER_PROMPT_TEMPLATE = "Please evaluate the exercise form shown. What mistakes, if any, are present, and what corrections would you recommend?"
+FEEDBACK_PROMPT_TEMPLATE = "Please evaluate the exercise form shown. What feedback would you provide to improve the performance?"
 
 # Dataset split ratios (adjustable)
 TRAIN_RATIO = 0.60
@@ -19,8 +23,8 @@ VAL_RATIO = 0.20
 TEST_RATIO = 0.20
 RANDOM_SEED = 42  # For reproducibility
 
-def main():
-    # Load manifest to map video filenames to full paths
+def load_manifest():
+    """Load manifest and create lookup dictionaries"""
     with open(MANIFEST_JSON, 'r') as f:
         manifest = json.load(f)
 
@@ -40,8 +44,15 @@ def main():
         else:
             filename_to_exercise[filename] = str(exercise).replace('_', ' ')
 
-    # Load fine-grained labels
-    with open(FINE_LABELS_JSON, 'r') as f:
+    return filename_to_path, filename_to_exercise
+
+def process_fine_grained_labels(fine_labels_path, filename_to_path, filename_to_exercise):
+    """Process fine-grained labels JSON file"""
+    if not fine_labels_path.exists():
+        print(f"Warning: {fine_labels_path} not found, skipping fine-grained labels processing")
+        return []
+
+    with open(fine_labels_path, 'r') as f:
         fine_labels = json.load(f)
 
     # Convert to Mobile-VideoGPT format
@@ -89,57 +100,298 @@ def main():
                 {"from": "human", "value": user_prompt},
                 {"from": "gpt", "value": assistant_answer}
             ],
-            "split": "train"  # Will be updated during split
+            "split": "train",  # Will be updated during split
+            "filename": filename  # Keep filename for cross-reference
         })
 
-    # Shuffle data for random split
+    return output_data
+
+def process_feedbacks(feedbacks_path, filename_to_path, filename_to_exercise):
+    """Process feedbacks JSON file"""
+    if not feedbacks_path.exists():
+        print(f"Warning: {feedbacks_path} not found, skipping feedbacks processing")
+        return []
+
+    with open(feedbacks_path, 'r') as f:
+        feedbacks = json.load(f)
+
+    # Convert to Mobile-VideoGPT format
+    output_data = []
+
+    for record in feedbacks:
+        video_path = record.get('video_path', '')
+        # Extract filename from path (handles ./ prefix)
+        filename = os.path.basename(video_path)
+
+        # Look up full path in manifest
+        if filename not in filename_to_path:
+            print(f"Warning: {filename} not found in manifest, skipping")
+            continue
+
+        full_video_path = filename_to_path[filename]
+        exercise = filename_to_exercise[filename]
+
+        # Remove 'dataset/' prefix if present to make path relative to data_path
+        if full_video_path.startswith('dataset/'):
+            relative_video_path = full_video_path[len('dataset/'):]
+        else:
+            relative_video_path = full_video_path
+
+        # Get feedbacks and join them
+        feedbacks_list = record.get('feedbacks', [])
+        if isinstance(feedbacks_list, list):
+            assistant_answer = '\n'.join(str(item) for item in feedbacks_list)
+        else:
+            assistant_answer = str(feedbacks_list)
+
+        if not assistant_answer.strip():
+            assistant_answer = "No feedback available."
+
+        user_prompt = FEEDBACK_PROMPT_TEMPLATE
+
+        output_data.append({
+            "video": relative_video_path,
+            "conversations": [
+                {"from": "human", "value": user_prompt},
+                {"from": "gpt", "value": assistant_answer}
+            ],
+            "split": "train",  # Will be updated during split
+            "filename": filename  # Keep filename for cross-reference
+        })
+
+    return output_data
+
+def split_data_consistently(data1, data2):
+    """
+    Split two datasets consistently - same videos go to same splits in same order.
+    Returns (train1, val1, test1, train2, val2, test2)
+    """
+    # Create filename to index mappings
+    filename_to_idx1 = {item['filename']: idx for idx, item in enumerate(data1)}
+    filename_to_idx2 = {item['filename']: idx for idx, item in enumerate(data2)}
+
+    # Find common filenames
+    common_filenames = set(filename_to_idx1.keys()) & set(filename_to_idx2.keys())
+
+    if not common_filenames:
+        print("Warning: No common videos found between the two datasets")
+        return [], [], [], [], [], []
+
+    # Create paired list with common videos
+    common_list = list(common_filenames)
+
+    # Shuffle for random split
     random.seed(RANDOM_SEED)
-    random.shuffle(output_data)
+    random.shuffle(common_list)
 
     # Calculate split indices
-    total_count = len(output_data)
+    total_count = len(common_list)
     train_end = int(total_count * TRAIN_RATIO)
     val_end = train_end + int(total_count * VAL_RATIO)
 
-    # Split the data
-    train_data = output_data[:train_end]
-    val_data = output_data[train_end:val_end]
-    test_data = output_data[val_end:]
+    # Split filenames
+    train_filenames = common_list[:train_end]
+    val_filenames = common_list[train_end:val_end]
+    test_filenames = common_list[val_end:]
 
-    # Update split labels
-    for item in train_data:
-        item["split"] = "train"
-    for item in val_data:
-        item["split"] = "val"
-    for item in test_data:
-        item["split"] = "test"
+    # Create split datasets maintaining order
+    def create_split(filenames, dataset, filename_to_idx, split_name):
+        split_data = []
+        for filename in filenames:
+            idx = filename_to_idx[filename]
+            item = dataset[idx].copy()
+            item['split'] = split_name
+            # Remove filename from output (it was only for cross-reference)
+            item.pop('filename', None)
+            split_data.append(item)
+        return split_data
 
-    # Write output JSONs
-    BASE_DIR.mkdir(parents=True, exist_ok=True)
+    train_data1 = create_split(train_filenames, data1, filename_to_idx1, "train")
+    val_data1 = create_split(val_filenames, data1, filename_to_idx1, "val")
+    test_data1 = create_split(test_filenames, data1, filename_to_idx1, "test")
 
-    with open(OUTPUT_TRAIN_JSON, 'w') as f:
-        json.dump(train_data, f, indent=2)
+    train_data2 = create_split(train_filenames, data2, filename_to_idx2, "train")
+    val_data2 = create_split(val_filenames, data2, filename_to_idx2, "val")
+    test_data2 = create_split(test_filenames, data2, filename_to_idx2, "test")
 
-    with open(OUTPUT_VAL_JSON, 'w') as f:
-        json.dump(val_data, f, indent=2)
+    return train_data1, val_data1, test_data1, train_data2, val_data2, test_data2
 
-    with open(OUTPUT_TEST_JSON, 'w') as f:
-        json.dump(test_data, f, indent=2)
+def main():
+    # Load manifest
+    filename_to_path, filename_to_exercise = load_manifest()
 
-    print(f"\n{'='*60}")
-    print(f"Dataset Split Summary")
-    print(f"{'='*60}")
-    print(f"Total videos: {total_count}")
-    print(f"Exercise classes: {len(set(filename_to_exercise.values()))}")
-    print(f"\nSplit Distribution:")
-    print(f"  Train: {len(train_data)} samples ({len(train_data)/total_count*100:.1f}%)")
-    print(f"  Val:   {len(val_data)} samples ({len(val_data)/total_count*100:.1f}%)")
-    print(f"  Test:  {len(test_data)} samples ({len(test_data)/total_count*100:.1f}%)")
-    print(f"\nOutput files:")
-    print(f"  Train: {OUTPUT_TRAIN_JSON}")
-    print(f"  Val:   {OUTPUT_VAL_JSON}")
-    print(f"  Test:  {OUTPUT_TEST_JSON}")
-    print(f"{'='*60}")
+    # Process both datasets
+    fine_data = []
+    feedbacks_data = []
+
+    if FINE_GRAINED_JSON.exists():
+        fine_data = process_fine_grained_labels(FINE_GRAINED_JSON, filename_to_path, filename_to_exercise)
+        print(f"Using fine-grained labels from: {FINE_GRAINED_JSON}")
+
+    if FEEDBACKS_JSON.exists():
+        feedbacks_data = process_feedbacks(FEEDBACKS_JSON, filename_to_path, filename_to_exercise)
+        print(f"Using feedbacks from: {FEEDBACKS_JSON}")
+
+    # Check if we have data to process
+    if not fine_data and not feedbacks_data:
+        print("Error: No input data files found. Need at least one of:")
+        print(f"  - {FINE_GRAINED_JSON}")
+        print(f"  - {FEEDBACKS_JSON}")
+        return
+
+    # If we have both datasets, split them consistently
+    if fine_data and feedbacks_data:
+        train_fine, val_fine, test_fine, train_fb, val_fb, test_fb = split_data_consistently(fine_data, feedbacks_data)
+
+        # Write fine-grained labels splits
+        BASE_DIR.mkdir(parents=True, exist_ok=True)
+        with open(OUTPUT_TRAIN_JSON, 'w') as f:
+            json.dump(train_fine, f, indent=2)
+        with open(OUTPUT_VAL_JSON, 'w') as f:
+            json.dump(val_fine, f, indent=2)
+        with open(OUTPUT_TEST_JSON, 'w') as f:
+            json.dump(test_fine, f, indent=2)
+
+        # Write feedbacks splits
+        with open(OUTPUT_FEEDBACKS_TRAIN_JSON, 'w') as f:
+            json.dump(train_fb, f, indent=2)
+        with open(OUTPUT_FEEDBACKS_VAL_JSON, 'w') as f:
+            json.dump(val_fb, f, indent=2)
+        with open(OUTPUT_FEEDBACKS_TEST_JSON, 'w') as f:
+            json.dump(test_fb, f, indent=2)
+
+        print(f"\n{'='*60}")
+        print(f"Dataset Split Summary (Both Datasets)")
+        print(f"{'='*60}")
+        print(f"Total common videos: {len(train_fine) + len(val_fine) + len(test_fine)}")
+        print(f"Exercise classes: {len(set(filename_to_exercise.values()))}")
+        print(f"\nFine-Grained Labels Split:")
+        print(f"  Train: {len(train_fine)} samples ({len(train_fine)/(len(train_fine)+len(val_fine)+len(test_fine))*100:.1f}%)")
+        print(f"  Val:   {len(val_fine)} samples ({len(val_fine)/(len(train_fine)+len(val_fine)+len(test_fine))*100:.1f}%)")
+        print(f"  Test:  {len(test_fine)} samples ({len(test_fine)/(len(train_fine)+len(val_fine)+len(test_fine))*100:.1f}%)")
+        print(f"\nFeedbacks Split:")
+        print(f"  Train: {len(train_fb)} samples ({len(train_fb)/(len(train_fb)+len(val_fb)+len(test_fb))*100:.1f}%)")
+        print(f"  Val:   {len(val_fb)} samples ({len(val_fb)/(len(train_fb)+len(val_fb)+len(test_fb))*100:.1f}%)")
+        print(f"  Test:  {len(test_fb)} samples ({len(test_fb)/(len(train_fb)+len(val_fb)+len(test_fb))*100:.1f}%)")
+        print(f"\nFine-Grained Labels Output files:")
+        print(f"  Train: {OUTPUT_TRAIN_JSON}")
+        print(f"  Val:   {OUTPUT_VAL_JSON}")
+        print(f"  Test:  {OUTPUT_TEST_JSON}")
+        print(f"\nFeedbacks Output files:")
+        print(f"  Train: {OUTPUT_FEEDBACKS_TRAIN_JSON}")
+        print(f"  Val:   {OUTPUT_FEEDBACKS_VAL_JSON}")
+        print(f"  Test:  {OUTPUT_FEEDBACKS_TEST_JSON}")
+        print(f"{'='*60}")
+
+    # If we only have one dataset, use the original splitting logic
+    elif fine_data:
+
+        # Remove filename field before processing
+        for item in fine_data:
+            item.pop('filename', None)
+
+        # Shuffle data for random split
+        random.seed(RANDOM_SEED)
+        random.shuffle(fine_data)
+
+        # Calculate split indices
+        total_count = len(fine_data)
+        train_end = int(total_count * TRAIN_RATIO)
+        val_end = train_end + int(total_count * VAL_RATIO)
+
+        # Split the data
+        train_data = fine_data[:train_end]
+        val_data = fine_data[train_end:val_end]
+        test_data = fine_data[val_end:]
+
+        # Update split labels
+        for item in train_data:
+            item["split"] = "train"
+        for item in val_data:
+            item["split"] = "val"
+        for item in test_data:
+            item["split"] = "test"
+
+        # Write output JSONs
+        BASE_DIR.mkdir(parents=True, exist_ok=True)
+
+        with open(OUTPUT_TRAIN_JSON, 'w') as f:
+            json.dump(train_data, f, indent=2)
+
+        with open(OUTPUT_VAL_JSON, 'w') as f:
+            json.dump(val_data, f, indent=2)
+
+        with open(OUTPUT_TEST_JSON, 'w') as f:
+            json.dump(test_data, f, indent=2)
+
+        print(f"\n{'='*60}")
+        print(f"Dataset Split Summary (Fine-Grained Labels Only)")
+        print(f"{'='*60}")
+        print(f"Total videos: {total_count}")
+        print(f"Exercise classes: {len(set(filename_to_exercise.values()))}")
+        print(f"\nSplit Distribution:")
+        print(f"  Train: {len(train_data)} samples ({len(train_data)/total_count*100:.1f}%)")
+        print(f"  Val:   {len(val_data)} samples ({len(val_data)/total_count*100:.1f}%)")
+        print(f"  Test:  {len(test_data)} samples ({len(test_data)/total_count*100:.1f}%)")
+        print(f"\nOutput files:")
+        print(f"  Train: {OUTPUT_TRAIN_JSON}")
+        print(f"  Val:   {OUTPUT_VAL_JSON}")
+        print(f"  Test:  {OUTPUT_TEST_JSON}")
+        print(f"{'='*60}")
+
+    elif feedbacks_data:
+        # Remove filename field before processing
+        for item in feedbacks_data:
+            item.pop('filename', None)
+
+        # Shuffle data for random split
+        random.seed(RANDOM_SEED)
+        random.shuffle(feedbacks_data)
+
+        # Calculate split indices
+        total_count = len(feedbacks_data)
+        train_end = int(total_count * TRAIN_RATIO)
+        val_end = train_end + int(total_count * VAL_RATIO)
+
+        # Split the data
+        train_data = feedbacks_data[:train_end]
+        val_data = feedbacks_data[train_end:val_end]
+        test_data = feedbacks_data[val_end:]
+
+        # Update split labels
+        for item in train_data:
+            item["split"] = "train"
+        for item in val_data:
+            item["split"] = "val"
+        for item in test_data:
+            item["split"] = "test"
+
+        # Write output JSONs
+        BASE_DIR.mkdir(parents=True, exist_ok=True)
+
+        with open(OUTPUT_FEEDBACKS_TRAIN_JSON, 'w') as f:
+            json.dump(train_data, f, indent=2)
+
+        with open(OUTPUT_FEEDBACKS_VAL_JSON, 'w') as f:
+            json.dump(val_data, f, indent=2)
+
+        with open(OUTPUT_FEEDBACKS_TEST_JSON, 'w') as f:
+            json.dump(test_data, f, indent=2)
+
+        print(f"\n{'='*60}")
+        print(f"Dataset Split Summary (Feedbacks Only)")
+        print(f"{'='*60}")
+        print(f"Total videos: {total_count}")
+        print(f"Exercise classes: {len(set(filename_to_exercise.values()))}")
+        print(f"\nSplit Distribution:")
+        print(f"  Train: {len(train_data)} samples ({len(train_data)/total_count*100:.1f}%)")
+        print(f"  Val:   {len(val_data)} samples ({len(val_data)/total_count*100:.1f}%)")
+        print(f"  Test:  {len(test_data)} samples ({len(test_data)/total_count*100:.1f}%)")
+        print(f"\nOutput files:")
+        print(f"  Train: {OUTPUT_FEEDBACKS_TRAIN_JSON}")
+        print(f"  Val:   {OUTPUT_FEEDBACKS_VAL_JSON}")
+        print(f"  Test:  {OUTPUT_FEEDBACKS_TEST_JSON}")
+        print(f"{'='*60}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
**Dataset download and initialization improvements:**

- Added an interactive prompt in `scripts/initialize_dataset.sh` to enable optional parallel downloads for faster processing, passing a `--parallel` flag to `load_dataset.py` when selected.
- Made ground truth filtering optional with a user prompt, allowing users to skip this step if desired. The summary output at the end of the script now reflects whether ground truth filtering was performed.

**Dataset download script (`utils/dataset/load_dataset.py`) enhancements:**

- Added support for parallel downloads using `ThreadPoolExecutor`, improving download speed for large datasets. The script now parses a `--parallel` flag and handles both sequential and parallel modes.
- Extended the download logic to fetch both `fine_grained_labels.json` and the new `feedbacks_short_clips.json`, supporting the new feedbacks dataset.

**Dataset processing and splitting (`utils/dataset/qved_from_fine_labels.py`) upgrades:**

- Refactored the script to process both fine-grained labels and feedbacks datasets, generating separate output files for each and ensuring that train/val/test splits are consistent across both datasets (i.e., the same videos are assigned to the same split in both).
- Added new output files for feedbacks splits: `qved_feedbacks_train.json`, `qved_feedbacks_val.json`, and `qved_feedbacks_test.json`.